### PR TITLE
Refactor Condenser API wrapper and add endpoint validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@
 .keys
 
 sendgrid.env
+.env.dev*
+.env.staging
+.env.production
+env.sh

--- a/app/controllers/concerns/condenser_safe.rb
+++ b/app/controllers/concerns/condenser_safe.rb
@@ -9,7 +9,7 @@
 #
 # IMPORTANT
 #   All methods use keyword arguments.
-#   Controllers should never call Condenser::API directly.
+#   Controllers should prefer safe wrappers when available.
 
 module CondenserSafe
   extend ActiveSupport::Concern
@@ -97,7 +97,7 @@ module CondenserSafe
 
   def safe_resource(id:)
     safe_condenser(default: {}, action: "resource #{id}") do
-      Condenser::API.resource(id: id)
+      Condenser::API.resource(uri: id)
     end
   end
 
@@ -108,7 +108,7 @@ module CondenserSafe
 
   def safe_search_statements(uri:)
     safe_condenser(default: [], action: "search #{uri}") do
-      Condenser::API.search_statements(uri: uri)
+      Condenser::API.search_statements(cache: uri)
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -202,7 +202,13 @@ class EventsController < ApplicationController
   end
 
   def review_event
-    data = Condenser::API.review_all_statements params[:event_id], current_user.name, params[:review_next], params[:seedurl]
+    data = Condenser::API.review_all_statements(
+      event_id: params[:event_id],
+      user_name: current_user.name,
+      review_next: params[:review_next],
+      seedurl: params[:seedurl]
+    )
+
     if data.blank?
       flash[:danger] = "Failed to update!"
       redirect_back(fallback_location: root_path)
@@ -224,7 +230,7 @@ class EventsController < ApplicationController
 
   def destroy
     #add call to condenser to destroy
-    data = Condenser::API.delete_resource params[:event_id]
+    data = Condenser::API.delete_resource_uri(uri: params[:event_id])
 
     if data[:error] then
       flash[:danger] = "Failed to unlink event."

--- a/app/controllers/linked_data_controller.rb
+++ b/app/controllers/linked_data_controller.rb
@@ -26,10 +26,13 @@ class LinkedDataController < ApplicationController
         params[:uri].split('---').second # passed by select2 autocomplete
       end
 
-    data = Condenser::API.add_linked_data  params[:statement_id], current_user.name,
-               {rdfs_class: params[:rdfs_class],
-                uri: uri,
-                name: name}
+    data = Condenser::API.add_linked_data(
+      id: params[:statement_id],
+      user_name: current_user.name,
+      rdfs_class: params[:rdfs_class],
+      uri: uri,
+      name: name
+    )
    
     @event = data["statements"]
     stat = @event.select{ |_n,v| v["id"] == params[:statement_id].to_i }.flatten[1]
@@ -57,10 +60,14 @@ class LinkedDataController < ApplicationController
     params[:name]
     params[:statement_id]
  
-    data = Condenser::API.remove_linked_data params[:statement_id], current_user.name,
-               {rdfs_class: params[:rdfs_class],
-                uri: params[:uri],
-                name: params[:name]}
+    data = Condenser::API.remove_linked_data(
+      id: params[:statement_id],
+      user_name: current_user.name,
+      rdfs_class: params[:rdfs_class],
+      uri: params[:uri],
+      name: params[:name]
+    )
+
     @event = data["statements"]
     stat = @event.select{ |_n,v| v["id"] == params[:statement_id].to_i }.flatten[1]
 
@@ -143,18 +150,23 @@ class LinkedDataController < ApplicationController
     end
 
     # call condenser condenser_create_linked_resource 
-    new_entity = Condenser::API.create_linked_resource params[:rdfs_class], params[:seedurl], options
+    new_entity = Condenser::API.create_linked_resource(
+      rdfs_class: params[:rdfs_class],
+      seedurl: params[:seedurl],
+      statements: options
+    )
    
     puts "new_entity: #{new_entity.inspect}"
 
     # Link to new resource and returns the event 
     if new_entity["statements"].present?
-      data = Condenser::API.add_linked_data params[:statement_id], current_user.name, 
-        { 
-          rdfs_class: params[:rdfs_class],
-          uri: new_entity["uri"],
-          name: new_entity["statements"]["name_#{params[:name_lang]}"]["value"]
-        }
+    data = Condenser::API.add_linked_data(
+      id: params[:statement_id],
+      user_name: current_user.name,
+      rdfs_class: params[:rdfs_class],
+      uri: new_entity["uri"],
+      name: new_entity["statements"]["name_#{params[:name_lang]}"]["value"]
+    )
       
       @event = data["statements"]
       stat = @event.select{ |_n,v| v["id"] == params[:statement_id].to_i }.flatten[1]

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -44,7 +44,11 @@ class MicropostsController < ApplicationController
     @micropost = current_user.microposts.build(micropost_params)
     if @micropost.save
       ##FLAG work goes here
-      data = Condenser::API.flag_statement @micropost.related_statement_id, current_user.name
+      data = Condenser::API.flag_statement(
+        id: @micropost.related_statement_id,
+        user_name: current_user.name
+      )
+
       @event = data["statements"]
       @seedurl = data["seedurl"]
       @website = Website.where(url: @seedurl, user_id: current_user).first

--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -12,7 +12,7 @@ class ResourceController < ApplicationController
               end
 
     if format == :jsonld || params[:format] == 'jsonld'
-      redirect_to "#{Condenser::API.url_per_environment}/graphs/webpage/event-artsdata.jsonld?rdf_uri=footlight:#{params[:id]}", status: 303
+      redirect_to "#{Condenser::API.base_url}/graphs/webpage/event-artsdata.jsonld?rdf_uri=footlight:#{params[:id]}", status: 303
     else
       redirect_to resource_index_path(uri: "footlight:" + params[:id]), status: 303
     end
@@ -22,7 +22,7 @@ class ResourceController < ApplicationController
   # GET /resource 
   def index 
     if params[:uri] 
-      @resource = safe_resource(params[:uri])
+      @resource = safe_resource(id: params[:uri])
 
       unless @resource["uri"].present?
         flash[:danger] = "Could not load resource."
@@ -51,20 +51,28 @@ class ResourceController < ApplicationController
     end
   end
 
-  # POST /resource/refresh)uri_uri=
+  # POST /resource/refresh_uri?uri=
   def refresh_uri
-    Condenser::API.refresh_rdf_uri_statements(params[:uri])
-    redirect_to resource_index_path(uri: params[:uri])
+    uri = params[:uri]
+
+    unless uri.present?
+      flash[:danger] = "Missing resource URI."
+      redirect_to resource_index_path and return
+    end
+
+    Condenser::API.refresh_rdf_uri_statements(rdf_uri: uri)
+
+    redirect_to resource_index_path(uri: uri)
   end
 
   def delete_uri
-    Condenser::API.delete_resource(CGI.unescape(params[:id]))
+    Condenser::API.delete_resource_uri(uri: CGI.unescape(params[:id]))
     flash[:success] = "Resource deleted. Attention: events may still be linked to this resource. Please delete individual links manually."
     redirect_to resource_index_url
   end
 
   def destroy
-    Condenser::API.delete_resource(params[:id])
+    Condenser::API.delete_resource_uri(uri: params[:id])
     flash[:success] = "Resource deleted. Attention: events may still be linked to this resource. Please delete individual links manually."
     redirect_to resource_index_url
   end

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -92,7 +92,12 @@ class SourcesController < ApplicationController
   # Review all statements by property (can include en and fr sources)
   # PATCH /sources/1?seedurl=
   def update
-    data = Condenser::API.review_all_statements_by_property params[:id], current_user.name, params[:seedurl]
+    data = Condenser::API.review_all_statements_by_property(
+      property_id: params[:id],
+      user_name: current_user.name,
+      seedurl: params[:seedurl]
+    )
+
     if data[:error]
       flash[:danger] = "Failed to review all! #{CGI.escape(data.to_s)}"
     else

--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -141,7 +141,11 @@ class StatementsController < ApplicationController
     @old_statement_id = params[:old_statement_id]
 
     data = call_condenser(action: :save_manual_statement) do
-      condenser_service.condenser_save_individual_statement(id, value, current_user.name)
+      Condenser::API.save_individual_statement(
+        id: id,
+        value: value,
+        user_name: current_user.name
+      )
     end
 
     return unless validate_statement_response(data, "save statement")
@@ -215,7 +219,7 @@ class StatementsController < ApplicationController
     return nil if id == old_id
 
     data = call_condenser(action: :activate_statement) do
-      condenser_service.condenser_activate_statement(id)
+      Condenser::API.activate_statement(id: id)
     end
 
     return nil unless validate_statement_response(data, "activate statement")

--- a/app/services/condenser/api.rb
+++ b/app/services/condenser/api.rb
@@ -13,105 +13,218 @@
 # Usage examples:
 #   Condenser::API.website_events(seedurl: "example", start_date: "2015-01-01")
 #   Condenser::API.property_statements(seedurl: "example", property_id: 5)
+# 
+# Architecture
+# ------------
+#
+#          Console
+#            ↓↑
+#      Condenser::API
+#            ↓↑
+#  ENDPOINTS (data contracts)
+#            ↓↑
+#     generic executor
+#            ↓↑ 
+#     Condenser client
+#            ↓↑
+#        HTTP client
+#            ↓↑
+#        Condenser
+#
+
+require "cgi/util"
 
 module Condenser
   module API
 
+    # --------------------------------------------------
+    # Endpoints: data transformations and retrieval 
+    # --------------------------------------------------
     ENDPOINTS = {
 
-      # Dashboard
-      dashboard_metrics: {
-        method: :get,
-        path: "/dashboard_metrics.json"
+      # --------------------------------------------------
+      # Dashboard: overall view of websites - health
+      # --------------------------------------------------
+      dashboard_metrics: { method: :get, 
+                          path: "/dashboard_metrics.json" },
+
+      # --------------------------------------------------
+      # Events: reviews all statements belonging to an event
+      # --------------------------------------------------
+      review_all_statements: {
+        method: :patch,
+        path: "/resources/:event_id/reviewed_all.json",
+        params: [:user_name, :review_next, :seedurl],
+        body_builder: ->(p) {
+          body = {
+            event: { status_origin: p[:user_name] }
+          }
+
+          body[:review_next] = p[:review_next] if p[:review_next]
+          body[:seedurl]     = p[:seedurl] if p[:seedurl]
+
+          body
+        }.freeze
       },
 
-      # Sources
-      sources: {
-        method: :get,
-        path: "/sources.json",
-        params: [:seedurl]
+      # --------------------------------------------------
+      # Properties: reviews all statements associated with a property
+      # --------------------------------------------------
+      review_all_statements_by_property: {
+        method: :patch,
+        path: "/properties/:property_id/review_all_statements.json",
+        params: [:user_name, :seedurl],
+        body_builder: ->(p) {
+          {
+            status: "ok",
+            status_origin: p[:user_name],
+            seedurl: p[:seedurl]
+          }
+        }.freeze
       },
 
-      source: {
-        method: :get,
-        path: "/sources/:id.json"
-      },
+      # --------------------------------------------------
+      # Resources: linked places, people and organizations
+      # --------------------------------------------------
+      create_linked_resource: { method: :post, 
+                                path: "/resources.json", 
+                                params: [:rdfs_class, :seedurl, :statements] },
 
-      # Websites
-      websites: {
-        method: :get,
-        path: "/websites.json"
-      },
+      delete_resource_uri:    { method: :delete, 
+                                path: "/resources/delete_uri.json", 
+                                params: [:uri] },
 
-      website_events: {
-        method: :get,
-        path: "/websites/:seedurl/events.json",
-        params: [:start_date, :end_date],
-        param_aliases: {
-          start_date: "startDate",
-          end_date: "endDate"
-        }
-      },
+      resource:               { method: :get, 
+                                path: "/resources.json", 
+                                params: [:uri] },
 
-      website_resources: {
-        method: :get,
-        path: "/websites/:seedurl/resources.json"
-      },
+      website_resources:      { method: :get, 
+                                path: "/websites/:seedurl/resources.json" },
 
-      # Resources
-      resource: {
-        method: :get,
-        path: "/resources/:id.json"
-      },
+      # --------------------------------------------------
+      # Sources: 
+      # --------------------------------------------------
+      source: { method: :get, 
+                path: "/sources/:id.json" },
 
-      create_linked_resource: {
-        method: :post,
-        path: "/resources.json",
-        params: [:seedurl, :rdf_uri]
-      },
+      sources: { method: :get, 
+                path: "/sources.json", 
+                params: [:seedurl] },
 
-      delete_resource: {
-        method: :delete,
-        path: "/resources/:id.json"
-      },
-
+      # --------------------------------------------------
       # Statements
-      search_statements: {
-        method: :get,
-        path: "/statements.json",
-        params: [:subject]
+      # --------------------------------------------------
+      activate_individual_statement:   { method: :patch, 
+                                        path: "/statements/:id/activate_individual.json" },
+
+      activate_statement:              { method: :patch, 
+                                        path: "/statements/:id/activate.json" },
+
+      add_linked_data: {
+        method: :patch,
+        path: "/statements/:id/add_linked_data.json",
+        params: [:user_name, :name, :rdfs_class, :uri],
+        body_builder: ->(p) {
+          {
+            statement: {
+              cache: "[\"#{p[:name]}\",\"#{p[:rdfs_class]}\",\"#{p[:uri]}\"]",
+              status: "ok",
+              status_origin: p[:user_name]
+            }
+          }
+        }.freeze
       },
 
-      activate_statement: {
-        method: :patch,
-        path: "/statements/:id/activate.json"
-      },
+      deactivate_individual_statement: { method: :patch, 
+                                        path: "/statements/:id/deactivate_individual.json" },
 
-      activate_individual_statement: {
+      flag_statement: {
         method: :patch,
-        path: "/statements/:id/activate_individual.json"
-      },
-
-      deactivate_individual_statement: {
-        method: :patch,
-        path: "/statements/:id/deactivate_individual.json"
+        path: "/statements/:id.json",
+        params: [:user_name],
+        body_builder: ->(p) {
+          {
+            statement: {
+              status: "problem",
+              status_origin: p[:user_name]
+            }
+          }
+        }.freeze
       },
 
       reconnect_feed_statement: {
         method: :patch,
-        path: "/statements/:id/reconnect_feed.json"
+        path: "/statements/:id/reconnect_feed.json",
+        params: [:user_name],
+        body_builder: ->(p) {
+          {
+            statement: {
+              manual: false,
+              status_origin: p[:user_name]
+            }
+          }
+        }.freeze
       },
 
-      save_individual_statement: {
+      refresh_rdf_uri_statements:      { method: :patch, 
+                                        path: "/statements/refresh_rdf_uri.json",             
+                                        params: [:rdf_uri] },
+
+      remove_linked_data:              { 
+        method: :patch, 
+        path: "/statements/:id/remove_linked_data.json",
+        params: [:user_name, :name, :rdfs_class, :uri],
+        body_builder: ->(p) {
+          {
+            statement: {
+              cache: "[\"#{p[:name]}\",\"#{p[:rdfs_class]}\",\"#{p[:uri]}\"]",
+              status: "ok",
+              status_origin: p[:user_name]
+            }
+          }
+        }.freeze
+      },
+
+      review_statement: {
         method: :patch,
-        path: "/statements/:id/save_individual.json"
+        path: "/statements/:id.json",
+        params: [:user_name],
+        body_builder: ->(p) {
+          {
+            statement: {
+              status: "ok",
+              status_origin: p[:user_name]
+            }
+          }
+        }.freeze
       },
 
-      refresh_rdf_uri_statements: {
-        method: :post,
-        path: "/statements/refresh_rdf_uri.json",
-        params: [:seedurl]
+      save_individual_statement: { 
+        method: :patch, 
+        path: "/statements/:id.json",
+        params: [:user_name, :value],
+        body_builder: ->(p) {
+          {
+            statement: {
+              cache: p[:value].to_s,
+              status: "ok",
+              status_origin: p[:user_name]
+            }
+          }
+        }.freeze
       },
+
+      save_statement:                  { method: :patch, 
+                                        path: "/statements/:id.json",                          
+                                        params: [:statement] },
+
+      search_statements:               { method: :get, 
+                                        path: "/statements.json",                                
+                                        params: [:cache] },
+
+      # --------------------------------------------------
+      # Websites: 
+      # --------------------------------------------------
 
       property_statements: {
         method: :get,
@@ -121,77 +234,106 @@ module Condenser
           property_id: "property",
           start_date: "startDate",
           end_date: "endDate"
-        }
+        }.freeze
       },
 
-      # Events
-      review_all_statements: {
-        method: :post,
-        path: "/events/:event_id/review_all_statements.json"
-      }
+      website_events: {
+        method: :get,
+        path: "/websites/:seedurl/events.json",
+        params: [:start_date, :end_date],
+        param_aliases: {
+          start_date: "startDate",
+          end_date: "endDate"
+        }.freeze
+      },
+
+      websites: { method: :get, path: "/websites.json" }
 
     }.freeze
 
-    ENDPOINTS.each do |name, endpoint|
-      raise "Endpoint #{name} missing :method" unless endpoint[:method]
-      raise "Endpoint #{name} missing :path" unless endpoint[:path]
+    # Initialize path_keys
+    ENDPOINTS.each do |_, endpoint|
+      endpoint[:path_keys] =
+        endpoint[:path].scan(/:(\w+)/).flatten.map(&:to_sym).freeze
+    end
 
-      unless [:get, :post, :patch, :delete].include?(endpoint[:method])
-        raise "Endpoint #{name} has invalid method #{endpoint[:method]}"
+    # Validate endpoints
+    Condenser::API::EndpointsValidator.validate!
+
+    # --------------------------------------------------
+    # Operation
+    # --------------------------------------------------
+    ENDPOINTS.each do |name, endpoint|
+      define_singleton_method(name) do |**params|
+        execute_endpoint(name, endpoint, params)
       end
     end
 
-    # Singleton client
+    # --------------------------------------------------
+    # Utilities
+    # --------------------------------------------------
     def self.client
       @client ||= Condenser::Client.new
     end
-
-
-    ENDPOINTS.each do |name, endpoint|
-
-      define_singleton_method(name) do |**params|
-
-        method        = endpoint[:method]
-        path_template = endpoint[:path]
-
-        # Extract path params from template
-        path_keys = path_template.scan(/:(\w+)/).flatten.map(&:to_sym)
-
-        # Validate required path params
-        missing = path_keys - params.keys
-        if missing.any?
-          raise ArgumentError,
-            "Missing params for #{name}: #{missing.join(', ')}"
-        end
-
-        # Validate unknown params (Ruby interface)
-        allowed = (endpoint[:params] || []) + path_keys
-
-        unknown = params.keys - allowed
-        if unknown.any?
-          raise ArgumentError,
-            "Unknown params for #{name}: #{unknown.join(', ')}. Allowed: #{allowed.join(', ')}"
-        end
-
-        # Convert snake_case → API param names
-        params = normalize_params(params, endpoint[:param_aliases])
-
-        # Substitute path parameters
-        path = path_template.gsub(/:(\w+)/) { params.delete($1.to_sym) }
-
-        # Determine query/body
-        query = method == :get ? params : nil
-        body  = method != :get ? params : nil
-
-        client.request(
-          method: method,
-          path: path,
-          query: query,
-          body: body
-        )
-      end
+    
+    def self.base_url
+      client.base_url
     end
 
+
+    private
+
+    def self.execute_endpoint(name, endpoint, params)
+      params = params.transform_keys(&:to_sym)
+
+      method        = endpoint[:method]
+      path_template = endpoint[:path]
+
+      # Extract path parameters
+      path_keys = endpoint[:path_keys] || []
+
+      # Validate required/allowed path params
+      allowed = path_keys + Array(endpoint[:params])
+
+      assert_no_missing_params!(name, endpoint, params)
+      assert_no_unknown_params!(name, endpoint, params, allowed)
+
+      Rails.logger.debug("[CondenserAPI] params before path substitution: #{params.inspect}")
+
+      # Substitute path parameters
+      path = path_template.gsub(/:(\w+)/) do
+        value = params.delete($1.to_sym)
+        CGI.escape(value.to_s)
+      end
+
+      # Normalize params 
+      params = normalize_params(params, endpoint[:param_aliases])
+
+      # Build request body
+      if endpoint[:body_builder]
+        body  = endpoint[:body_builder].call(params)
+        query = nil
+      else
+        query = method == :get ? params : nil
+        body  = method != :get ? params : nil
+      end
+
+      # Log 
+      payload = query || body
+      Rails.logger.info(
+        "→ [CondenserAPI] #{name} #{method.to_s.upcase} path=#{path} params=#{params.inspect} payload=#{payload.inspect}"
+      )
+
+      # Engage! :)
+      client.request(
+        method: method,
+        path: path,
+        query: query,
+        body: body
+      )
+    end
+
+private
 
     # Normalize parameters
     # --------------------
@@ -203,32 +345,26 @@ module Condenser
       params.each_with_object({}) do |(key, value), normalized|
         next if value.nil?
 
-        normalized[aliases.fetch(key, key)] = value
+        normalized[aliases[key] || key] = value
       end
     end
 
+    # Check for missings
+    def self.assert_no_missing_params!(name, endpoint, params)
+      missing = endpoint[:path_keys] - params.keys
+      return if missing.empty?
 
-    def self.base_url
-      client.base_url
+      raise ArgumentError,
+        "\n\n\t********* Missing params for #{name} (#{endpoint[:path]}): #{missing.join(', ')} *********\n"
     end
 
+    # Check for unknowns
+    def self.assert_no_unknown_params!(name, endpoint, params, allowed)
+      unknown = params.keys - allowed
+      return if unknown.empty?
 
-    # Debug helpers
-    # -------------
-
-    def self.routes
-      ENDPOINTS.keys
-    end
-
-
-    def self.print_routes
-      ENDPOINTS.each do |name, endpoint|
-        puts "%-25s %-6s %s" % [
-          name,
-          endpoint[:method].to_s.upcase,
-          endpoint[:path]
-        ]
-      end
+      raise ArgumentError,
+        "\n\n\t********* Unknown params for #{name} (#{endpoint[:path]}): #{unknown.join(', ')}. Allowed: #{allowed.join(', ')} *********\n"
     end
 
   end

--- a/app/services/condenser/api/endpoints_docs.rb
+++ b/app/services/condenser/api/endpoints_docs.rb
@@ -1,0 +1,58 @@
+module Condenser
+  module API
+    module EndpointsDocs
+
+      def self.describe(name)
+        endpoint = Condenser::API::ENDPOINTS[name]
+
+        puts "Name: #{name}"
+        puts "Method: #{endpoint[:method].to_s.upcase}"
+        puts "Path: #{endpoint[:path]}"
+        puts "Params: #{endpoint[:params] || []}"
+      end
+
+      def self.routes
+        Condenser::API::ENDPOINTS.keys
+      end
+
+      def self.print_routes
+        Condenser::API::ENDPOINTS.each do |name, endpoint|
+          puts "%-25s %-6s %s" % [
+            name,
+            endpoint[:method].to_s.upcase,
+            endpoint[:path]
+          ]
+        end
+      end
+
+      def self.endpoint_docs
+        Condenser::API::ENDPOINTS.map do |name, spec|
+          {
+            name: name,
+            method: spec[:method],
+            path: spec[:path],
+            params: spec[:params] || [],
+            example: build_example(name, spec)
+          }
+        end
+      end
+
+      def self.build_example(name, spec)
+        params = (spec[:params] || []).map { |p| "#{p}: <value>" }.join(", ")
+        "#{name}(#{params})"
+      end
+
+      def self.print_docs
+        endpoint_docs.each do |ep|
+          puts
+          puts ep[:name]
+          puts "  #{ep[:method].to_s.upcase} #{ep[:path]}"
+          puts "  params: #{ep[:params].join(', ')}"
+          puts "  example:"
+          puts "    Condenser::API.#{ep[:example]}"
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/condenser/api/endpoints_validator.rb
+++ b/app/services/condenser/api/endpoints_validator.rb
@@ -1,0 +1,69 @@
+module Condenser
+  module API
+    module EndpointsValidator
+
+      VALID_METHODS = [:get, :post, :patch, :delete].freeze
+
+      def self.validate!
+        Condenser::API::ENDPOINTS.each do |name, endpoint|
+          validate_endpoint_structure!(name, endpoint)
+          validate_endpoint_contract!(name, endpoint)
+        end
+      end
+
+      def self.validate_endpoint_structure!(name, endpoint)
+        raise "Endpoint #{name} must be a Hash" unless endpoint.is_a?(Hash)
+
+        raise "Endpoint #{name} missing :method" unless endpoint[:method]
+        raise "Endpoint #{name} missing :path" unless endpoint[:path]
+
+        unless VALID_METHODS.include?(endpoint[:method])
+          raise "Endpoint #{name} has invalid method #{endpoint[:method]}"
+        end
+
+        endpoint[:path_keys] =
+          endpoint[:path].scan(/:(\w+)/).flatten.map(&:to_sym).freeze
+
+        # Duplicates ?
+        seen = {}
+
+        Condenser::API::ENDPOINTS.each do |name, ep|
+          key = [
+            ep[:method],
+            ep[:path],
+            ep[:params],
+            ep[:param_aliases],
+            ep[:body_builder]&.source_location
+          ]
+
+          if seen[key]
+            raise "Duplicate endpoint operation: #{name} and #{seen[key]}"
+          end
+
+          seen[key] = name
+        end
+      end
+
+
+      def self.validate_endpoint_contract!(name, endpoint)
+        if endpoint[:params]
+          overlap = endpoint[:params] & endpoint[:path_keys]
+          raise "Endpoint #{name} params overlap path keys: #{overlap}" unless overlap.empty?
+        end
+
+        if endpoint[:params] && !endpoint[:params].is_a?(Array)
+          raise "Endpoint #{name} params must be an Array"
+        end
+
+        if endpoint[:param_aliases] && !endpoint[:param_aliases].is_a?(Hash)
+          raise "Endpoint #{name} param_aliases must be a Hash"
+        end
+
+        if endpoint[:body_builder] && !endpoint[:body_builder].respond_to?(:call)
+          raise "Endpoint #{name} body_builder must respond to :call"
+        end
+      end
+
+    end
+  end
+end

--- a/app/services/statements/reviewer.rb
+++ b/app/services/statements/reviewer.rb
@@ -2,7 +2,7 @@
 module Statements
   class Reviewer
     def self.call(statement_id:, user_name:)
-      data = ApplicationController.Condenser::API.review_statement(statement_id, user_name)
+      data = Condenser::API.review_statement(id: statement_id, user_name: user_name)
 
       return Statements::Result.new(error: data) unless valid_response?(data)
 


### PR DESCRIPTION
- Introduce EndpointsValidator to centralize API endpoint validation
- Automatically derive path_keys from endpoint paths
- Restore safe initialization of endpoint[:path_keys] before execution
- Preserve previous params/path validation contract
- Fix refresh behavior to correctly use params[:uri]
- Address issues identified in Codex review of previous PR